### PR TITLE
Enable compression for zipfile

### DIFF
--- a/slave.py
+++ b/slave.py
@@ -142,7 +142,7 @@ class Slave(object):
 
     # Write out the archive
     archive_buffer = cStringIO.StringIO()
-    with zipfile.ZipFile(archive_buffer, "w") as myzip:
+    with zipfile.ZipFile(archive_buffer, "w", zipfile.ZIP_DEFLATED) as myzip:
       for m in all_matched:
         arcname = os.path.relpath(m, test_dir)
         while arcname.startswith("/"):


### PR DESCRIPTION
Contrary to what one might expect, the default behavior for zipfile
is to not compress anything. This adds the correct flag to actually
compress the artifacts before uploading them to S3.
