### PR TITLE
Fix bug in touching beanstalk queue elements

### DIFF
--- a/slave.py
+++ b/slave.py
@@ -200,8 +200,9 @@ class Slave(object):
         LOG.info("Still running: " + task.task.description)
         self.submit_load_metric(1)
         try:
-          self.bs_elem.touch()
+          task.bs_elem.touch()
         except:
+          LOG.info("Could not touch beanstalk queue elem", exc_info=True)
           pass
         last_touch = time.time()
 


### PR DESCRIPTION
A mistaken merge conflict resolution meant that, while a job
was running, we weren't pinging beanstalk to let it know that
progress was being made. This meant that if a job lasted longer
than 2 minutes, another retry would be scheduled.
