### PR TITLE
Swallow additional kwargs to _fetch, like no_wait

### DIFF
--- a/client.py
+++ b/client.py
@@ -234,7 +234,7 @@ def fetch(argv):
 
   _fetch(job_id, **vars(options))
 
-def _fetch(job_id, out_dir, artifacts=False, logs=False, failed_only=False):
+def _fetch(job_id, out_dir, artifacts=False, logs=False, failed_only=False, **kwargs):
   # Fetch the finished tasks for the job
   status = failed_only and 'failed' or 'finished'
   tasks = fetch_tasks(job_id, status=status)


### PR DESCRIPTION
Specifying "--artifacts" does not work right now, since it passes the no_wait arg to _fetch, which barfs.

I decided to just swallow additional kwargs in _fetch, though there are other approaches if you prefer.
