### PR TITLE
Use contextlib to workaround Python 2.6 zipfile not supporting 'with'…

### DIFF
--- a/client.py
+++ b/client.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import with_statement
+import contextlib
 import getpass
 import logging
 import multiprocessing
@@ -336,7 +337,7 @@ def _extract(path, out_dir):
     os.makedirs(dest_path)
     LOG.debug("Extracting %s into %s", path, dest_path)
     try:
-      with zipfile.ZipFile(path, "r") as myzip:
+      with contextlib.closing(zipfile.ZipFile(path, "r")) as myzip:
         for info in myzip.infolist():
             myzip.extract(info, dest_path)
     except Exception as e:


### PR DESCRIPTION
… statement.

See:

http://stackoverflow.com/questions/32884277/how-can-i-avoid-zipfile-instance-has-no-attribute-exit-when-extracting

Tested "client.py fetch --artifacts" with both 2.6 and 2.7
