### PR TITLE
add docker-compose.yml

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+docker-compose.yml
+.git

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,82 @@
+# Docker Compose file for dist_test
+#
+# Usage:
+#
+#     $ export AWS_ACCESS_KEY=foo AWS_SECRET_KEY=bar TEST_RESULT_BUCKET=your-s3-bucket
+#     $ docker-compose up
+#     $ docker exec disttest_client_1 sh -c 'cd grind/python/disttest/test/test-resources/MultiModuleTestProject && grind test'
+
+version: '2'
+services:
+  mysql:
+    image: mysql:5.6.26
+    environment:
+      - MYSQL_ROOT_PASSWORD=dist_test
+      - MYSQL_DATABASE=dist_test
+      - MYSQL_USER=dist_test
+      - MYSQL_PASSWORD=dist_test
+    restart: always
+  beanstalk:
+    build:
+      context: ./docker
+      dockerfile: Dockerfile.beanstalk
+    restart: always
+  isolate:
+    build:
+      context: ./docker
+      dockerfile: Dockerfile.isolate
+    restart: always
+  master:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.master
+    environment:
+      - AWS_ACCESS_KEY
+      - AWS_SECRET_KEY
+      - TEST_RESULT_BUCKET
+    volumes:
+      - ./docker/config/dist_test.cnf:/root/.dist_test.cnf
+    entrypoint:
+      - sh
+      - -c
+      - sleep 10 && ./infra/server.py
+    links:
+      - beanstalk
+      - mysql
+    ports:
+      - "8081:8081"
+    restart: always
+  worker:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.worker
+    environment:
+      - AWS_ACCESS_KEY
+      - AWS_SECRET_KEY
+      - TEST_RESULT_BUCKET
+    volumes:
+      - ./docker/config/dist_test.cnf:/root/.dist_test.cnf
+    entrypoint:
+      - sh
+      - -c
+      - sleep 10 && ./infra/slave.py
+    links:
+      - master
+      - beanstalk
+      - isolate
+      - mysql
+    restart: always
+  client:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.client
+    volumes:
+      - ./docker/config/grind.cfg:/root/.grind/grind.cfg
+    entrypoint:
+      # hack for keep the container running
+      - tail
+      - -f
+      - /dev/null
+    links:
+      - master
+      - isolate

--- a/docker/Dockerfile.beanstalk
+++ b/docker/Dockerfile.beanstalk
@@ -1,0 +1,7 @@
+FROM ubuntu:16.04
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends \
+  beanstalkd
+
+EXPOSE 11300
+CMD ["beanstalkd", "-p", "11300"]

--- a/docker/Dockerfile.client
+++ b/docker/Dockerfile.client
@@ -1,0 +1,28 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  build-essential \
+  gawk \
+  git \
+  maven openjdk-8-jdk \
+  python python-dev python-pip python-setuptools python-virtualenv \
+  unzip \
+  virtualenv \
+  wget
+
+# Install dist_test
+ADD . /dist_test
+WORKDIR /dist_test
+ENV PATH=/dist_test/grind/bin:$PATH
+
+# bake the default config into the image
+RUN mkdir -p /root/.grind && cp ./docker/config/grind.cfg.sample /root/.grind/grind.cfg
+
+# pre-install isolate (first run installs the isolate binary)
+RUN /dist_test/bin/isolate version
+
+# pre-build the grind test
+RUN cd grind/python/disttest/test/test-resources/MultiModuleTestProject && \
+  mvn clean package -DskipTests
+
+# no entrypoint

--- a/docker/Dockerfile.isolate
+++ b/docker/Dockerfile.isolate
@@ -1,0 +1,13 @@
+FROM golang:1.4
+
+# toddlipcon's fork
+ARG LUCI_GO_COMMIT=6f8431521270754084d85b593604ff46f9ac51b1
+
+## Install LUCI
+RUN mkdir -p $GOPATH/src/github.com/luci && \
+  ( cd $GOPATH/src/github.com/luci && \
+    git clone https://github.com/toddlipcon/luci-go && \
+    cd luci-go && git checkout $LUCI_GO_COMMIT && \
+    go get github.com/luci/luci-go/server/isolateserver )
+
+ENTRYPOINT ["isolateserver"]

--- a/docker/Dockerfile.master
+++ b/docker/Dockerfile.master
@@ -1,0 +1,26 @@
+FROM ubuntu:16.04
+
+ARG LUCI_PY_COMMIT=1f8ba359e84dc7f26b1ba286dfb4e28674efbff4
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  build-essential \
+  git \
+  libmysqlclient-dev \
+  python python-dev python-pip python-setuptools
+
+# Install LUCI
+RUN pip install -t lib google-api-python-client
+RUN cd / && git clone https://github.com/luci/luci-py.git && \
+  cd luci-py && git checkout $LUCI_PY_COMMIT
+
+# Install pip dependency (master)
+RUN pip install jinja2 cherrypy beanstalkc MySQL-python boto PyYAML simple_json netaddr==0.7.18
+
+# Install dist_test
+ADD . /dist_test
+WORKDIR /dist_test
+
+# bake the default config into the image
+RUN cp ./docker/config/dist_test.cnf.sample /root/.dist_test.cnf
+
+# no entrypoint

--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -1,0 +1,29 @@
+FROM ubuntu:16.04
+
+ARG LUCI_PY_COMMIT=1f8ba359e84dc7f26b1ba286dfb4e28674efbff4
+
+# gawk and unzip are  needed for running MultiModuleTestProject
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  build-essential \
+  gawk unzip \
+  git \
+  libmysqlclient-dev \
+  maven openjdk-8-jdk \
+  python python-dev python-pip python-setuptools
+
+# Install LUCI
+RUN pip install -t lib google-api-python-client
+RUN cd / && git clone https://github.com/luci/luci-py.git && \
+  cd luci-py && git checkout $LUCI_PY_COMMIT
+
+# Install pip dependency (worker)
+RUN pip install beanstalkc MySQL-python boto glob2 PyYAML
+
+# Install dist_test
+ADD . /dist_test
+WORKDIR /dist_test
+
+# bake the default config into the image
+RUN cp ./docker/config/dist_test.cnf.sample /root/.dist_test.cnf
+
+# no entrypoint

--- a/docker/config/dist_test.cnf
+++ b/docker/config/dist_test.cnf
@@ -1,0 +1,1 @@
+dist_test.cnf.sample

--- a/docker/config/dist_test.cnf.sample
+++ b/docker/config/dist_test.cnf.sample
@@ -1,0 +1,24 @@
+[isolate]
+home=/luci-py
+server=http://isolate:4242
+cache_dir=/tmp/isolate-cache
+
+[aws]
+# you have to provide these environment variables (via docker-compose.yml):
+# - AWS_ACCESS_KEY
+# - AWS_SECRET_KEY
+# - TEST_RESULT_BUCKET
+# you need to create the bucket manually
+
+[mysql]
+host=mysql
+user=dist_test
+password=dist_test
+database=dist_test
+
+[beanstalk]
+host=beanstalk
+
+[dist_test]
+master=http://master:8081/
+allowed_ip_ranges=0.0.0.0/0

--- a/docker/config/grind.cfg
+++ b/docker/config/grind.cfg
@@ -1,0 +1,1 @@
+grind.cfg.sample

--- a/docker/config/grind.cfg.sample
+++ b/docker/config/grind.cfg.sample
@@ -1,0 +1,9 @@
+[grind]
+isolate_server = http://isolate:4242
+dist_test_client_path = /dist_test/bin/client
+dist_test_master = http://master:8081
+grind_cache_dir = /dist_test/env/.grind/cache
+grind_temp_dir = /dist_test/env/.grind/temp
+isolate_path = /dist_test/bin/isolate
+dist_test_password =
+dist_test_user =

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -9,6 +9,26 @@ You can run your own isolate server, `dist_test` server, slave, beanstalkd, and 
 
 https://github.com/apache/incubator-kudu/blob/master/build-support/dist_test.py
 
+### Docker-based setup
+
+You can use [Docker](https://www.docker.com/) for ease of setting up dist_test.
+This setup depends on [Docker Compose](https://docs.docker.com/compose/).
+Please also refer to the documentation of [Docker Compose](https://docs.docker.com/compose/).
+
+Start containers (`mysql`, `beanstalk`, `isolate`, `master`, `worker`, and `client`) with your AWS credential:
+
+        $ export AWS_ACCESS_KEY=foo AWS_SECRET_KEY=bar TEST_RESULT_BUCKET=your-s3-bucket
+        $ docker-compose up
+
+Then you can execute [a grind test](#client-setup) in the client container:
+
+        $ docker exec disttest_client_1 sh -c 'cd grind/python/disttest/test/test-resources/MultiModuleTestProject && grind test'
+		
+You can access the master UI via `http://localhost:8081/`.
+
+### Manual setup
+If you do not want to use Docker for setting up, you can set up the environment manually.
+
 The first step is to clone and build the required following additional repos we need.
 
 Luci is split into [luci-py](https://github.com/luci/luci-py) and [luci-go](https://github.com/luci/luci-go).


### PR DESCRIPTION
This PR adds docker-compose.yml so that people can easily set up a dist_test server.

``` console
$ docker-compose up
$ docker exec disttest_client_1 sh -c 'cd grind/python/disttest/test/test-resources/MultiModuleTestProject && grind test
[found] [hashed/size/to hash] [looked up/to lookup] [uploaded/size/to upload/size]

e7fafe89ac9ea1692b62761a20f750fa94c042ef  com.cloudera.disttest.TestFailAlways

fe433d5fe057a10887da029d505a8446ecb58663  com.cloudera.disttest.AppTest

2b450ca01b159e66190febf958d4eef2474dd3b6  com.cloudera.disttest.TestLinkedListReversal

8a71eac73cc9b129751ef6b1304ede4aced23daa  com.cloudera.disttest.TestHelloWorld

dd850a2f0e5d0d1a3fa5d09bbc983816f774f44f  com.cloudera.disttest.TestFailSometimes
[3625] [729/16.6Mib/729] [729/729] [477/6.07Mib/729/16.6Mib] 1s
[3625] [729/16.6Mib/729] [729/729] [727/12.2Mib/729/16.6Mib] 2s

Hits    :     0 (0b)
Misses  :   729 (16.6Mib)
Duration: 2.355s
INFO:__main__:Calling /dist_test/bin/client submit --name MultiModuleTestProject /dist_test/env/.grind/temp/grind.rHrA0Z/run.json
INFO:dist_test.client:Submitting job to http://master:8081/submit_job
INFO:dist_test.client:Submitted job MultiModuleTestProject.root.1477393038.139
INFO:dist_test.client:Watch your results at http://master:8081/job?job_id=MultiModuleTestProject.root.1477393038.139
 0.0s    0/5 tests complete
 7.1s    1/5 tests complete
 13.2s   2/5 tests complete (1 failed)
 17.2s   3/5 tests complete (1 failed)
 20.8s   4/5 tests complete (1 failed)
 26.3s   5/5 tests complete (2 failed)
WARNING:__main__:Test run failed!
```
