### PR TITLE
slave: run run_isolated in "headless" mode

### DIFF
--- a/infra/server.py
+++ b/infra/server.py
@@ -29,9 +29,12 @@ DIGEST_AUTH_KEY = random.getrandbits(4096)
 
 class Authorize(cherrypy.Tool):
 
-  def __init__(self, allowed_ip_ranges=None, accounts=None):
+  def __init__(self, allowed_ip_ranges=None, accounts={}):
     self.allowed_ranges = [netaddr.IPNetwork(a) for a in allowed_ip_ranges]
-    self.accounts = accounts or {}
+    self.accounts = {}
+    for u, p in accounts.iteritems():
+      self.accounts[str(u)] = str(p)
+
     self._point = "before_handler"
     self._name = None
     self._priority = 50

--- a/infra/slave.py
+++ b/infra/slave.py
@@ -197,9 +197,14 @@ class Slave(object):
     if not self.results_store.mark_task_running(task.task):
       LOG.info("Task %s canceled", task.task.description)
       return
+    # Make run_isolated run in 'bot' mode. This prevents it from trying
+    # to use oauth to authenticate.
+    env = os.environ.copy()
+    env['SWARMING_HEADLESS'] = '1'
+
     LOG.info("Running command: %s", repr(cmd))
     p = subprocess.Popen(
-      cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+      cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
     pipes = [p.stdout, p.stderr]
     self._set_flags(p.stdout)
     self._set_flags(p.stderr)


### PR DESCRIPTION
This makes the slaves run 'run_isolated.py' in 'headless' mode, which
prevents it from attempting to use oauth authentication. In our setup,
the oauth authentication was already a no-op, so skipping it doesn't
change functionality.

As for the actual benefit of this change, I hope that this will reduce
the incidence of task failures due to errors like:

third_party.requests.exceptions.ConnectionError:
HTTPConnectionPool(host='isolateserver', port=4242): Max retries
exceeded with url: /auth/api/v1/server/oauth_config (Caused by <class
'socket.error'>: [Errno 110] Connection timed out)

(apparently the oauth login had no built-in retries, whereas the actual
data fetches do retry)