### PR TITLE
grind: add parent POMs to packaged maven repo

### DIFF
--- a/grind/python/disttest/packager.py
+++ b/grind/python/disttest/packager.py
@@ -349,7 +349,11 @@ class Packager:
         if self.__verbose:
             quiet_flag = ""
 
-        cmd = """%s --settings %s %s dependency:copy-dependencies -Dmdep.useRepositoryLayout=true -Dmdep.copyPom -DoutputDirectory=%s %s"""
+        cmd = ("%s --settings %s %s dependency:copy-dependencies " +
+               "-Dmdep.useRepositoryLayout=true " +
+               "-Dmdep.copyPom " +
+               "-Dmdep.addParentPoms " +
+               "-DoutputDirectory=%s %s")
         cmd = cmd % (env_mvn, settings_xml, quiet_flag, cached_m2_repo, copy_deps_flags)
         Packager.__shell(cmd, self.__project_root)
 


### PR DESCRIPTION
Previously we were not copying parent POMs into the maven repository
shipped to the slaves. This meant that the parents had to be resolved
from remote Maven repositories, which could fail in cases such as
testing a snapshot of an unreleased version.