### PR TITLE
Fix #26 isolate fatal error: MSpanList_Insert on macOS Sierra.

### DIFF
--- a/bin/isolate
+++ b/bin/isolate
@@ -12,7 +12,14 @@ ISOLATE_BIN="$DIR/bin"
 
 OS="linux"
 if [ "$(uname)" == "Darwin" ]; then
-    OS="osx"
+    ver=$(sw_vers -productVersion)
+    if [[ "$ver" < "10.12" ]]; then
+        # macOS earlier than Sierra
+        OS="osx"
+    else
+        # macOS Sierra or later
+        OS="osx-sierra"
+    fi
 fi
 
 ISOLATE_DIR="$ENV/$OS"


### PR DESCRIPTION
Use a new isolate build for hash 69b5913d2932a6c71209a5a15ec6fa3af56bb73f (Todd 6/3/2015) with Go 1.7.1.

Test result:
`INFO:disttest.isolate:Success! Generated 1 isolate descriptions in /Users/jzhuge/.grind/temp/grind.jXSPg5
--2016-10-14 08:56:45--  https://s3-us-west-2.amazonaws.com/hdfs-cce/isolate-bin/osx/10.12/isolate
Resolving s3-us-west-2.amazonaws.com... 54.231.177.12
Connecting to s3-us-west-2.amazonaws.com|54.231.177.12|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 9240268 (8.8M) [application/octet-stream]
Saving to: ‘/Users/jzhuge/dist_test/bin/../env/osx/isolate’

/Users/jzhuge/dist_test/bin/../env/osx/isolate 100%[====================================================================================================>]   8.81M  10.1MB/s    in 0.9s    

2016-10-14 08:56:46 (10.1 MB/s) - ‘/Users/jzhuge/dist_test/bin/../env/osx/isolate’ saved [9240268/9240268]

[found] [hashed/size/to hash] [looked up/to lookup] [uploaded/size/to upload/size]
[2473] [2473/189.6Mib/2473] [0/2473] [0/0b/0/0b] 300ms
038ffd3d1819f941c0bbfd14cb630c0d016681dc  org.apache.hadoop.crypto.key.kms.server.TestKMS
[2474] [2474/190.0Mib/2474] [2474/2474] [552/516.7Kib/556/517.4Kib] 6.7s
Hits    :  1918 (189.5Mib)
Misses  :   556 (517.4Kib)
Duration: 6.669s
INFO:__main__:Calling /Users/jzhuge/dist_test/infra/client.py submit --name hadoop2 /Users/jzhuge/.grind/temp/grind.jXSPg5/run.json
INFO:dist_test.client:Submitting job to http://dist-test.cloudera.org:80/submit_job
INFO:dist_test.client:Submitted job hadoop2.jzhuge.1476460613.32049
INFO:dist_test.client:Watch your results at http://dist-test.cloudera.org:80/job?job_id=hadoop2.jzhuge.1476460613.32049
 198.2s         10/10 tests complete
`