### PR TITLE
grind: Add option to specify Maven settings.xml

### DIFF
--- a/grind/bin/grind
+++ b/grind/bin/grind
@@ -189,6 +189,7 @@ class ProjectConfig(BaseConfig):
         "file_patterns": "[]",
         "file_globs": "[]",
         "artifact_archive_globs": """["**/surefire-reports/TEST-*.xml"]""",
+        "maven_settings": "null",
     }
 
     default_location = os.path.join(os.getcwd(), ".grind_project.cfg")
@@ -342,6 +343,8 @@ class TestRunner:
                             dest='artifacts',
                             help="Whether to download test artifacts.")
         # Misc
+        parser.add_argument('--maven-settings',
+                            help="The Maven settings.xml to use.")
         parser.add_argument('-n', '--num',
                             type=int,
                             default=1,
@@ -400,6 +403,7 @@ class TestRunner:
                             exclude_patterns = self.args.exclude_patterns,
                             cache_dir = self.config.grind_cache_dir,
                             extra_deps = extra_deps,
+                            maven_settings = self.args.maven_settings or self.project_config.maven_settings,
                             maven_flags = maven_flags,
                             maven_repo = maven_repo,
                             verbose = self.args.verbose)

--- a/grind/python/disttest/isolate.py
+++ b/grind/python/disttest/isolate.py
@@ -62,7 +62,8 @@ class Isolate:
 
     def __init__(self, project_root, output_dir,
                  include_modules=None, exclude_modules=None, include_patterns=None, exclude_patterns=None,
-                 cache_dir=None, extra_deps=None, maven_flags=None, maven_repo=None, verbose=False):
+                 cache_dir=None, extra_deps=None, maven_flags=None,
+                 maven_repo=None, maven_settings=None, verbose=False):
         logger.info("Using output directory " + output_dir)
         self.output_dir = output_dir
         self.maven_project = mavenproject.MavenProject(project_root,
@@ -72,6 +73,7 @@ class Isolate:
                                                        exclude_patterns=exclude_patterns)
         self.packager = packager.Packager(self.maven_project, self.output_dir,
                                           cache_dir=cache_dir, extra_deps=extra_deps,
+                                          maven_settings = maven_settings,
                                           maven_flags = maven_flags, maven_repo = maven_repo,
                                           verbose = verbose)
         self.isolated_files = []

--- a/grind/python/disttest/packager.py
+++ b/grind/python/disttest/packager.py
@@ -193,7 +193,7 @@ class Packager:
     _MAVEN_REL_ROOT = ".m2/repository"
 
     def __init__(self, maven_project, output_root,
-                 cache_dir=None, extra_deps=None, ignore=None,
+                 cache_dir=None, extra_deps=None, ignore=None, maven_settings=None,
                  maven_flags=None, maven_repo=None, verbose=False):
         self.__maven_project = maven_project
         self.__project_root = maven_project.project_root
@@ -214,6 +214,7 @@ class Packager:
         self.__test_jars = []
         self.__test_dirs = []
         self.__jars = []
+        self.__maven_settings = maven_settings
         self.__maven_repo = maven_repo
         self.__maven_flags = ""
         if maven_flags is not None:
@@ -381,6 +382,12 @@ class Packager:
         # If the project's manifest does not match the manifest of the project's cached dependencies,
         # we need to regenerate the Maven dependencies since they may be out of date.
         self._regenerate_dependency_cache_if_necessary()
+
+        # Copy user specified Maven settings.xml
+        if self.__maven_settings:
+            src = os.path.expanduser(self.__maven_settings)
+            logger.info("Copy %s to %s", src, self.__cached_project_root)
+            shutil.copy(src, self.__cached_project_root)
 
         # Hardlink from the cache to the output folder
         logger.info("Linking cached Maven dependencies from %s to %s", self.__cached_project_root, self.__output_root)


### PR DESCRIPTION
Add option to specify a Maven settings.xml to use.
In both argument and project config.
This fixes #28.