### PR TITLE
Set the default Java version of grind to 7 for backward compatibility.

### DIFF
--- a/docs/grind.md
+++ b/docs/grind.md
@@ -142,7 +142,7 @@ As an example, here is Hadoop's `.grind_project.cfg`. Hadoop tests expect a few 
         empty_dirs = ["test/data", "test-dir", "log"]
         file_globs = []
         file_patterns = ["*.so"]
-        java_version = 8
+        java_version = 7
 
 Common issues when onboarding
 -----------------------------

--- a/docs/grind.md
+++ b/docs/grind.md
@@ -131,7 +131,7 @@ Per-project Configuration
 * `file_globs`: Specifies additional test dependencies via a comma-delimited list of Unix-style path globs. These globs are interpreted by Python's [glob.iglob](https://docs.python.org/2/library/glob.html#glob.iglob).
 * `file_patterns`: Specifies additional test dependencies via a comma-delimited list of filename patterns. These patterns are interpreted by Python's [fnmatch.fnmatch](https://docs.python.org/2/library/fnmatch.html#fnmatch.fnmatch).
 * `artifact_archive_globs`: Specifies test output to upload after a test has run, via comma-delimited Python glob.iglob glob strings. By default, this matches Surefire's test XML output (`**/surefire-reports/TEST-*.xml`), but it can be modified to also upload additional logs.
-* `java_version`: Chooses the runtime JDK version. Supported values are 7 or 8.
+* `java_version`: Chooses the runtime JDK version. Supported values are 7 or 8, the default is 7.
 
 Like the `grind config` command, `pconfig` will generate a default config to the default location (`./grind_project.cfg`) when invoked via `grind pconfig --generate --write`.
 

--- a/grind/bin/grind
+++ b/grind/bin/grind
@@ -32,7 +32,7 @@ from disttest import util
 
 logger = logging.getLogger(__name__)
 supported_java_versions = [7, 8]
-default_java_version = 8
+default_java_version = 7
 
 
 class BaseConfig:


### PR DESCRIPTION
Change default Java version to 7 for backward compatibility. Check CDH-48954 for the details.