### PR TITLE
Fix server UI bug that incorrectly counts running jobs as failed

### DIFF
--- a/infra/server.py
+++ b/infra/server.py
@@ -283,7 +283,7 @@ class DistTestServer(object):
     result['running_tasks'] = len([1 for t in tasks if t['status'] is None])
     result['retried_tasks'] = len([1 for t in tasks if t['attempt'] > 0])
     result['timedout_tasks'] = len([1 for t in tasks if t['status'] == -9])
-    result['failed_tasks'] = len([1 for t in tasks if t['status'] != 0])
+    result['failed_tasks'] = len([1 for t in tasks if t['status'] is not None and t['status'] != 0])
     result['succeeded_tasks'] = len([1 for t in tasks if t['status'] == 0])
 
     # Group-level status information


### PR DESCRIPTION
Currently, when a job is submitted, the running test cases will show under both 'running' and 'failed' on the job summary page. This commit fixes the 'failed' to only show the jobs that really failed.

Tested on local setup.