### PR TITLE
Add retries when isolate batcharchive failed.

### DIFF
--- a/grind/bin/grind
+++ b/grind/bin/grind
@@ -17,12 +17,14 @@ import ConfigParser
 import json
 import logging
 import os
+import random
 import shlex
 import shutil
 import StringIO
 import subprocess
 import sys
 import tempfile
+import time
 
 sys.path = [os.path.realpath(os.path.join(os.path.dirname(os.path.realpath(__file__)), "../python"))] + sys.path
 from disttest import merge_xunit
@@ -439,11 +441,17 @@ class TestRunner:
         cmd = "%s batcharchive --dump-json=%s --"
         hashes_file = os.path.join(self.output_dir, "hashes.json")
         cmd = cmd % (self.config.isolate_path, hashes_file)
-        logger.debug("Invoking %s", cmd)
-        p = subprocess.Popen(shlex.split(cmd) + i.isolated_files, env=isolate_env)
-        p.wait()
-        if p.returncode != 0:
-            raise Exception("isolate batcharchive failed")
+        for retry in range(0, 3):
+            # retry a couple of times to overcome connection timeouts.
+            logger.debug("Invoking %s", cmd)
+            p = subprocess.Popen(shlex.split(cmd) + i.isolated_files, env=isolate_env)
+            p.wait()
+            if p.returncode != 0:
+                if retry == 2:
+                    raise Exception("isolate batcharchive failed")
+                else:
+                    logger.debug("isolate batcharchive failed with error code %s", p.returncode)
+                    time.sleep(random.randint(10, 60))
 
         # Parse the dumped json file and turn it into task descriptions
         # for dist_test

--- a/grind/bin/grind
+++ b/grind/bin/grind
@@ -441,13 +441,13 @@ class TestRunner:
         cmd = "%s batcharchive --dump-json=%s --"
         hashes_file = os.path.join(self.output_dir, "hashes.json")
         cmd = cmd % (self.config.isolate_path, hashes_file)
-        for retry in range(0, 3):
+        for num_retries_remaining in range(3, 0):
             # retry a couple of times to overcome connection timeouts.
             logger.debug("Invoking %s", cmd)
             p = subprocess.Popen(shlex.split(cmd) + i.isolated_files, env=isolate_env)
             p.wait()
             if p.returncode != 0:
-                if retry == 2:
+                if retry == 1:
                     raise Exception("isolate batcharchive failed")
                 else:
                     logger.debug("isolate batcharchive failed with error code %s", p.returncode)

--- a/grind/bin/grind
+++ b/grind/bin/grind
@@ -441,13 +441,13 @@ class TestRunner:
         cmd = "%s batcharchive --dump-json=%s --"
         hashes_file = os.path.join(self.output_dir, "hashes.json")
         cmd = cmd % (self.config.isolate_path, hashes_file)
-        for num_retries_remaining in range(3, 0):
+        for num_retries_remaining in range(3, -1, -1):
             # retry a couple of times to overcome connection timeouts.
             logger.debug("Invoking %s", cmd)
             p = subprocess.Popen(shlex.split(cmd) + i.isolated_files, env=isolate_env)
             p.wait()
             if p.returncode != 0:
-                if retry == 1:
+                if num_retries_remaining == 0:
                     raise Exception("isolate batcharchive failed")
                 else:
                     logger.debug("isolate batcharchive failed with error code %s", p.returncode)


### PR DESCRIPTION
We've seen intermittent failures isolate batch archive failures due to connection timeout. Adding a couple of retries should hopefully reduce some of these failures.

```
10:53:56 isolate: push() failed: Post http://isolate.cloudera.org:4242/_ah/api/isolateservice/v1/store_inline: write tcp 104.196.9.210:4242: connection timed out
10:53:56 
10:53:57 Traceback (most recent call last):
10:53:57   File "/data/jenkins/workspace/Hadoop-Flaky-Test-Rate-Runner/cloudera/dist_test/bin/grind", line 641, in <module>
10:53:57     main()
10:53:57   File "/data/jenkins/workspace/Hadoop-Flaky-Test-Rate-Runner/cloudera/dist_test/bin/grind", line 618, in main
10:53:57     subcommands[args.subparser_name](config, args)
10:53:57   File "/data/jenkins/workspace/Hadoop-Flaky-Test-Rate-Runner/cloudera/dist_test/bin/grind", line 632, in test_subcommand
10:53:57     runner.run()
10:53:57   File "/data/jenkins/workspace/Hadoop-Flaky-Test-Rate-Runner/cloudera/dist_test/bin/grind", line 396, in run
10:53:57     self.run_tests()
10:53:57   File "/data/jenkins/workspace/Hadoop-Flaky-Test-Rate-Runner/cloudera/dist_test/bin/grind", line 452, in run_tests
10:53:57     raise Exception("isolate batcharchive failed")
10:53:57 Exception: isolate batcharchive failed
10:53:57 Build step 'Execute shell' marked build as failure
10:53:57 Recording test results
```