### PR TITLE
Make server mysql port configurable

### DIFF
--- a/infra/config.py
+++ b/infra/config.py
@@ -12,6 +12,7 @@ class Config(object):
 
   # MySQL settings
   MYSQL_HOST_CONFIG = ('mysql', 'host', 'MYSQL_HOST')
+  MYSQL_PORT_CONFIG = ('mysql', 'port', 'MYSQL_PORT')
   MYSQL_USER_CONFIG = ('mysql', 'user', 'MYSQL_USER')
   MYSQL_PWD_CONFIG = ('mysql', 'password', 'MYSQL_PWD')
   MYSQL_DB_CONFIG = ('mysql', 'database', 'MYSQL_DB')
@@ -58,6 +59,10 @@ class Config(object):
 
     # MySQL settings
     self.MYSQL_HOST = self._get_with_env_override(*self.MYSQL_HOST_CONFIG)
+    try:
+      self.MYSQL_PORT = int(self._get_with_env_override(*self.MYSQL_PORT_CONFIG))
+    except:
+      self.MYSQL_PORT = 3306
     self.MYSQL_USER = self._get_with_env_override(*self.MYSQL_USER_CONFIG)
     self.MYSQL_PWD = self._get_with_env_override(*self.MYSQL_PWD_CONFIG)
     self.MYSQL_DB = self._get_with_env_override(*self.MYSQL_DB_CONFIG)

--- a/infra/dist_test.py
+++ b/infra/dist_test.py
@@ -179,11 +179,12 @@ class ResultsStore(object):
           self.thread_local.db is not None:
       return self.thread_local.db
     self.thread_local.db = MySQLdb.connect(
-      self.config.MYSQL_HOST,
-      self.config.MYSQL_USER,
-      self.config.MYSQL_PWD,
-      self.config.MYSQL_DB)
-    logging.info("Connected to MySQL at %s" % self.config.MYSQL_HOST)
+      host=self.config.MYSQL_HOST,
+      port=self.config.MYSQL_PORT,
+      user=self.config.MYSQL_USER,
+      passwd=self.config.MYSQL_PWD,
+      db=self.config.MYSQL_DB)
+    logging.info("Connected to MySQL at %s:%d" % (self.config.MYSQL_HOST, self.config.MYSQL_PORT))
     self.thread_local.db.autocommit(True)
     return self.thread_local.db
 


### PR DESCRIPTION
Add a configuration item for the port number of MySql db when setting up the dist-test server.