### PR TITLE
Resultserver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 server-env
 slave-env
+rs-env
 logs
 *.swp
 *.pyc

--- a/bin/result_server
+++ b/bin/result_server
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ENV="$DIR/../env"
+mkdir -p $ENV
+
+env_name="rs-env"
+
+# Check the git hash of when the virtualenv was created.
+# If it differs, wipe and reinitialize, saving a new hash.
+pushd "$DIR"
+git_hash=$(git rev-parse HEAD)
+popd
+hash_file="$ENV/$env_name/git-hash"
+if [[ ! -e "$hash_file" || "$git_hash" != "$(cat $hash_file)" ]]; then
+    echo "Initializing virtualenv"
+    pushd "$ENV"
+    virtualenv "$env_name"
+    for package in beanstalkc cherrypy jinja2 MySQL-python boto glob2 PyYAML; do
+        "./$env_name/bin/pip" install $package
+    done
+    virtualenv --relocatable "$env_name"
+    echo "$git_hash" > "$hash_file"
+    popd
+fi
+
+# Activate the virtualenv
+source "$ENV/$env_name/bin/activate"
+
+# Execute
+exec "$DIR/../infra/result_server.py" "$@"

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -64,6 +64,7 @@ Next, create a configuration file at `~/.dist_test.cnf` that looks like the foll
 
         [mysql]
         host=localhost
+        port=3306
         user=<FILL IN HERE>
         password=<FILL IN HERE>
         database=<FILL IN HERE>
@@ -74,6 +75,8 @@ Next, create a configuration file at `~/.dist_test.cnf` that looks like the foll
         [dist_test]
         master=http://localhost:8081/
         allowed_ip_ranges=0.0.0.0/0
+        #result_server=http://localhost:8080/ (Optional. Only used for test result submission)
+        #temp_dir=/tmp (Optional. Only used by the result server)
 
 Adjust `isolate.home` to point within your luci-py repo. The client folder should have a `run_isolated.py` file that is the key functionality we're using.
 
@@ -87,6 +90,10 @@ Start the master and one or more slaves:
 
         $ ./bin/server
         $ ./bin/slave
+
+Optionally, start the result server, if test result submission is needed:
+
+        $ ./bin/result_server
 
 `dist_test` will create the required tables in MySQL on first run.
 

--- a/grind/bin/grind
+++ b/grind/bin/grind
@@ -18,6 +18,7 @@ import json
 import logging
 import os
 import random
+import re
 import shlex
 import shutil
 import StringIO
@@ -27,6 +28,7 @@ import tempfile
 import time
 
 sys.path = [os.path.realpath(os.path.join(os.path.dirname(os.path.realpath(__file__)), "../python"))] + sys.path
+sys.path = [os.path.join(os.path.realpath(os.path.dirname(__file__)), "../../dist_test")] + sys.path
 from disttest import merge_xunit
 from disttest import isolate
 from disttest import packager
@@ -373,6 +375,10 @@ class TestRunner:
                             action='store_true',
                             dest="dry_run",
                             help="Do not actually run tests or perform remote operations. Useful for debugging.")
+        parser.add_argument('--submit-result',
+                            action='store_true',
+                            dest="submit_result",
+                            help="Submit the test result to the result server, for failure rate calculation.")
 
     @staticmethod
     def print_module_tree(root_module, prefix=""):
@@ -462,6 +468,7 @@ class TestRunner:
         if self.args.artifacts:
             artifacts_flags = shlex.split("--artifacts --output-dir grind-test-results")
 
+        out = None
         if self.args.dry_run:
             logging.info("Dry run, skipping test submission")
         else:
@@ -471,8 +478,8 @@ class TestRunner:
                    ["--name", os.path.basename(self.project_dir), tasks_file]
             logger.info("Calling %s", " ".join(cmd))
 
-            p = subprocess.Popen(cmd, env=isolate_env)
-            p.wait()
+            p = subprocess.Popen(cmd, env=isolate_env, stdout=subprocess.PIPE)
+            out, _ = p.communicate()
             # If we downloaded artifacts, then merge the results
             if self.args.artifacts:
                 in_files = []
@@ -481,6 +488,11 @@ class TestRunner:
                         if f.startswith("TEST-") and f.endswith(".xml"):
                             in_files.append(os.path.join(root, f))
                 merge_xunit.merge_xunit(in_files, "test_results.xml", ignore_flaky=True, quiet=True)
+                # TODO: support submitting single file to the result server
+                # submit_results.add_one_result("test_results.xml")
+            # else:
+                # TODO: support submitting a dir of test result xmls to the result server
+                # submit_results.add_one_result(self.output_dir)
             # Bubble up the return code from dist_test
             if p.returncode != 0:
                 if p.returncode == 88:
@@ -488,6 +500,28 @@ class TestRunner:
                     sys.exit(p.returncode)
                 else:
                     raise Exception("dist_test client submit failed")
+
+        if self.args.submit_result:
+            if out is None:
+              # both --dry-run and --submit-result are given
+              logging.info("No output from job submission, skipping result submission")
+              return
+            job_id = re.search(r'job_id=(.*)', out)
+            if job_id is None:
+              raise Exception("job_id not found for this run, cannot submit result")
+            job_id = job_id.group(1)
+            if job_id is None:
+              raise Exception("job_id not found, cannot submit result")
+            # submit with jobid.
+            grind_dir =  os.path.abspath(os.path.join(self.config.dist_test_client_path, "../.."))
+            submit_script_path = os.path.join(grind_dir, "infra/submit_results.py")
+            cmd = [submit_script_path, "--jobid", job_id]
+            logger.info("Calling %s", " ".join(cmd))
+            p = subprocess.Popen(cmd, env=isolate_env)
+            p.wait()
+            if p.returncode != 0:
+              logger.error("Test result submission failed! %s", p.returncode)
+              sys.exit(p.returncode)
 
     def cleanup(self):
         if self.args.leak_temp:

--- a/grind/python/disttest/parse_test_failure.py
+++ b/grind/python/disttest/parse_test_failure.py
@@ -1,0 +1,86 @@
+# !/usr/bin/env python
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# This script parses a test log (provided on stdin) and returns
+# a summary of the error which caused the test to fail.
+
+import sys
+import xml.etree.ElementTree as ET
+
+def consume_rest(line_iter):
+  """ Consume and return the rest of the lines in the iterator. """
+  return [l.group(0) for l in line_iter]
+
+def consume_until(line_iter, end_re):
+  """
+  Consume and return lines from the iterator until one matches 'end_re'.
+  The line matching 'end_re' will not be returned, but will be consumed.
+  """
+  ret = []
+  for l in line_iter:
+    line = l.group(0)
+    if end_re.search(line):
+      break
+    ret.append(line)
+  return ret
+
+# Parse log lines and return failure summary formatted as text.
+#
+# This helper function is part of a public API called from result_server.py
+def extract_failure_summary(log_text, name):
+  msg = None
+  st = None
+  stdout = None
+  stderr = None
+  suite = None
+
+  root = ET.fromstring(log_text)
+  (suite_name, case_name) = name.split('#')
+  if root.tag == "testsuite":
+    suite = root
+  else:
+    suite = root.find("testsuite")
+  if suite is not None:
+    for case in suite.getiterator("testcase"):
+      if case.get('name') != case_name:
+        continue
+      error = case.find("error")
+      if error is not None:
+        st = error.text
+        msg = error.get("message")
+      failure = case.find("failure")
+      if failure is not None:   # TODO
+        st = failure.text
+        msg = failure.get("type")
+      stdout = case.find("system-out")
+      if stdout is not None:
+        stdout = stdout.text
+      stderr = case.find("system-err")
+      if stderr is not None:
+        stderr = stderr.text
+
+  return (msg, st, stdout, stderr)
+
+def main(argv):
+  # local test mode, for debugging etc.
+  f = open(argv[1], 'r')
+  print extract_failure_summary(f.read(), argv[2])
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/infra/client.py
+++ b/infra/client.py
@@ -208,6 +208,8 @@ def submit(argv):
   retcode = do_watch_results(job_id)
   if options.artifacts:
     _fetch(job_id, **vars(options))
+  # print job_id to stdout, so the caller process (grind) can have it
+  print 'job_id=%s' % job_id
   sys.exit(retcode)
 
 def get_job_id_from_args(command, args):

--- a/infra/config.py
+++ b/infra/config.py
@@ -30,6 +30,8 @@ class Config(object):
   DIST_TEST_JOB_PATH_CONFIG = ('dist_test', 'job_path', 'DIST_TEST_JOB_PATH')
   DIST_TEST_USER_CONFIG = ('dist_test', 'user', 'DIST_TEST_USER')
   DIST_TEST_PASSWORD_CONFIG = ('dist_test', 'password', 'DIST_TEST_PASSWORD')
+  DIST_TEST_RESULT_SERVER_CONFIG = ('dist_test', 'result_server', 'DIST_TEST_RESULT_SERVER')
+  DIST_TEST_TEMP_DIR_CONFIG = ('dist_test', 'temp_dir', 'DIST_TEST_TEMP_DIR')
 
   def __init__(self, path=None):
     if path is None:
@@ -87,6 +89,9 @@ class Config(object):
     self.log_dir = self.config.get('dist_test', 'log_dir')
     # Make the log directory if it doesn't exist
     Config.mkdir_p(self.log_dir)
+    # dist_test result server settings
+    self.DIST_TEST_RESULT_SERVER = self._get_with_env_override(*self.DIST_TEST_RESULT_SERVER_CONFIG)
+    self.DIST_TEST_TEMP_DIR = self._get_with_env_override(*self.DIST_TEST_TEMP_DIR_CONFIG)
 
     self.SERVER_ACCESS_LOG = os.path.join(self.log_dir, "server-access.log")
     self.SERVER_ERROR_LOG = os.path.join(self.log_dir, "server-error.log")
@@ -134,6 +139,9 @@ class Config(object):
 
   def ensure_dist_test_configured(self):
     self._ensure_configs([self.DIST_TEST_MASTER_CONFIG])
+
+  def ensure_result_server_configured(self):
+    self._ensure_configs([self.DIST_TEST_RESULT_SERVER_CONFIG])
 
   def _ensure_configs(self, configs):
     for config in configs:

--- a/infra/result_server.py
+++ b/infra/result_server.py
@@ -1,0 +1,595 @@
+#!/usr/bin/env python
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Simple HTTP server which receives test results from the build slaves and
+# stores them in a MySQL database. The test logs are also stored in an S3 bucket.
+#
+
+import boto
+import cherrypy
+import contextlib
+import cStringIO
+import itertools
+import logging
+import MySQLdb
+import os
+import sys
+import threading
+import time
+import uuid
+import xml.etree.ElementTree as ET
+import zipfile
+
+sys.path = [os.path.realpath(os.path.join(os.path.dirname(os.path.realpath(__file__)), "../grind/python/disttest"))] + sys.path
+import parse_test_failure
+
+from config import Config
+from cStringIO import StringIO
+from jinja2 import Template
+from operator import itemgetter
+
+LOG = None
+
+# the test result server, to accumulate success + failed tests, and calculate failure rate.
+# TODO: add background thread to delete rows that are too old from DB.
+class ResultServer(object):
+  def __init__(self, config):
+    self.config = config
+    self.config.ensure_aws_configured()
+    self.config.ensure_mysql_configured()
+
+    self.thread_local = threading.local()
+    self._ensure_tables()
+    self.s3 = boto.connect_s3(self.config.AWS_ACCESS_KEY, self.config.AWS_SECRET_KEY)
+    self.s3_bucket = self.s3.get_bucket(self.config.AWS_TEST_RESULT_BUCKET)
+    self.test_dir=self.config.DIST_TEST_TEMP_DIR
+    if self.test_dir is None:
+      self.test_dir = "/tmp"
+
+  def _connect_mysql(self):
+    if hasattr(self.thread_local, "db") and \
+          self.thread_local.db is not None:
+      return self.thread_local.db
+
+    print "connecting to mysql: %s:%d" %( self.config.MYSQL_HOST, self.config.MYSQL_PORT)
+    self.thread_local.db = MySQLdb.connect(
+      host=self.config.MYSQL_HOST,
+      port=self.config.MYSQL_PORT,
+      user=self.config.MYSQL_USER,
+      passwd=self.config.MYSQL_PWD,
+      db=self.config.MYSQL_DB)
+    logging.info("Connected to MySQL at %s:%d" % (self.config.MYSQL_HOST, self.config.MYSQL_PORT))
+    self.thread_local.db.autocommit(True)
+    return self.thread_local.db
+
+  def _ensure_tables(self):
+    self._execute_query("""
+      CREATE TABLE IF NOT EXISTS dist_test_results (
+        id int not null auto_increment primary key,
+        timestamp timestamp not null default current_timestamp,
+        job_id varchar(100),
+        result_id varchar(150),
+        revision varchar(50),
+        hostname varchar(255),
+        test_name varchar(255),
+        status int,
+        log_key varchar(256),
+        INDEX (job_id),
+        INDEX (test_name),
+        INDEX (timestamp),
+        INDEX (status)
+      );""")
+
+  def _execute_query(self, query, *args, **kwargs):
+    """ Execute a query, automatically reconnecting on disconnection. """
+    # We'll try up to 3 times to reconnect
+    MAX_ATTEMPTS = 3
+
+    # Error code for the "MySQL server has gone away" error.
+    MYSQL_SERVER_GONE_AWAY = 2006
+
+    attempt_num = 0
+    while True:
+      c = self._connect_mysql().cursor(MySQLdb.cursors.DictCursor)
+      attempt_num = attempt_num + 1
+      try:
+        if kwargs.get('use_executemany', False):
+          c.executemany(query, *args)
+        else:
+          c.execute(query, *args)
+        return c
+      except MySQLdb.OperationalError as err:
+        if err.args[0] == MYSQL_SERVER_GONE_AWAY and attempt_num < MAX_ATTEMPTS:
+          logging.warn("Forcing reconnect to MySQL: %s" % err)
+          self.thread_local.db = None
+          continue
+        else:
+          raise
+
+  def _upload_string_to_s3(self, key, data):
+    k = boto.s3.key.Key(self.s3_bucket)
+    k.key = key
+    # The Content-Disposition header sets the filename that the browser
+    # will use to download this.
+    # We have to cast to str() here, because boto will try to escape the header
+    # incorrectly if you pass a unicode string.
+    k.set_metadata('Content-Disposition', str('inline; filename=%s' % key))
+    k.set_contents_from_string(data, reduced_redundancy=True)
+
+  def _download_string_from_s3(self, key):
+    k = boto.s3.key.Key(self.s3_bucket)
+    k.key = key
+    encoded_text = None
+    archive_buffer = StringIO(k.get_contents_as_string())
+
+    with contextlib.closing(zipfile.ZipFile(archive_buffer, 'r')) as myzip:
+      for filename in myzip.namelist():
+        try:
+          encoded_text = myzip.read(filename)
+        except KeyError:
+          LOG.error('Did not find %s in zip file' % filename)
+
+    # Ignore errors in decoding, as logs may contain binary data.
+    return encoded_text.decode('utf-8', 'ignore')
+
+  def get_root_from_s3key(self, key):
+    try:
+      log_text = self._download_string_from_s3(key)
+      return ET.fromstring(log_text)
+    except:
+      LOG.error('Failed to get xml root from s3 key(%s)' % key)
+      return None
+
+  @cherrypy.expose
+  def index(self):
+    return "Welcome to the test result server!"
+
+  def populate_database(self, job_id, result_id, revision, hostname, root, artifact_archive_key):
+    case_name = []
+    if root is None:
+      return 'Failure\n'
+
+    if root.tag != 'testsuite':
+      return "Failure!\n"
+    test_name = root.get('name')
+    for case in root.getiterator('testcase'):
+      result_code = 0
+      error = case.find("error")
+      failure = case.find('failure')
+      if error is not None:
+        result_code |= 1
+      if failure is not None:
+        result_code |= 2
+      # store failed test case names
+      case_name.append((case.get('name'), result_code))
+
+    for case, status in case_name:
+      parms = dict(job_id=job_id,
+                   result_id=result_id,
+                   revision=revision,
+                   hostname=hostname,
+                   test_name=test_name + '#' + case,
+                   status=status,
+                   log_key=artifact_archive_key)
+      logging.info("Handling report: %s" % repr(parms))
+      self._execute_query("""
+        INSERT INTO dist_test_results(job_id, result_id, revision, hostname, test_name, status, log_key)
+        VALUES (%(job_id)s, %(result_id)s, %(revision)s, %(hostname)s, %(test_name)s, %(status)s,
+        %(log_key)s)""", parms)
+    return "Success!\n"
+
+  def compress_file(self, test_report, id):
+    max_size = 200*1024*1024 # 200MB max uncompressed size
+    total_size = os.stat(test_report).st_size
+    if total_size > max_size:
+      # If size exceeds the maximum size, upload a zip with an error message instead
+      LOG.info("Task %s generated too many bytes of matched artifacts (%d > %d)," \
+               + "uploading archive with error message instead.",
+               id, total_size, max_size)
+      archive_buffer = cStringIO.StringIO()
+      with contextlib.closing(zipfile.ZipFile(archive_buffer, "w")) as myzip:
+        myzip.writestr("_ARCHIVE_TOO_BIG_",
+                       "Size of matched uncompressed test artifacts exceeded maximum size" \
+                       + "(%d bytes > %d bytes)!" % (total_size, max_size))
+      return archive_buffer
+
+    # Write out the archive
+    archive_buffer = cStringIO.StringIO()
+    with contextlib.closing(zipfile.ZipFile(archive_buffer, "w", zipfile.ZIP_DEFLATED)) as myzip:
+      arcname = os.path.relpath(test_report, self.test_dir)
+      while arcname.startswith("/"):
+        arcname = arcname[1:]
+      myzip.write(test_report, arcname)
+
+    return archive_buffer
+
+  @cherrypy.expose
+  # crawl from the test_task table, and populate result for a given job_id
+  def crawl_from_jobid(self, **kwargs):
+    # required: job_id, revision, hostname
+    args = {}
+    args.update(kwargs)
+    if 'job_id' not in args:
+      return "job_id is required."
+
+    args['revision']=''
+
+    # todo: optimization possible for status=0 jobs
+    # keep retrying until all rows in db has artifact_archive_key populated
+    all={}
+    done={}
+    timeout = time.time() + 60
+    while True:
+      # get all entries with given job_id from dist_test_tasks, then populate results
+      c = self._execute_query(
+                """SELECT
+                     job_id, task_id, attempt,
+                     hostname, artifact_archive_key, status
+                   FROM dist_test_tasks
+                   WHERE job_id = %(jobid)s""",
+                dict(jobid=args['job_id']))
+      rows = c.fetchall()
+      for row in rows:
+        uuid = row['job_id'] + row['task_id'] + str(row['attempt'])
+        if uuid not in all and uuid not in done:
+          all[uuid]=1
+        if row['artifact_archive_key'] is not None:
+          root = self.get_root_from_s3key(row['artifact_archive_key'])
+          ret = self.populate_database(row['job_id'], row['task_id'] + str(row['attempt']), args['revision'],
+                               row['hostname'], root, row['artifact_archive_key'])
+          LOG.debug('Finished for task %s, result is %s' % (uuid, ret))
+          all.pop(uuid, None)
+          done[uuid]=1
+      if bool(all) is False or time.time() > timeout:
+        break
+      time.sleep(3)
+      LOG.info('Retrying to crawl job %s since %s keys are not populated yet' % (args['job_id'], len(all)))
+
+    return "finished crawling from job", args['job_id']
+
+  @cherrypy.expose
+  def add_result(self, **kwargs):
+    # required: job_id, revision, hostname
+    # required: test_report or key.
+    # optional: result_id
+    args = {}
+    args.update(kwargs)
+    if 'job_id' not in args:
+      return 'FAILURE: job_id is required!'
+
+    if 'result_id' not in args:
+      args['result_id'] = ""
+
+    if 'test_report' in kwargs:
+      # We're given a local report file
+      test_report = kwargs['test_report']
+      f = open(test_report, 'r')
+      root = ET.parse(test_report).getroot()
+      if root.tag != 'testsuite':
+        return "Failure!\n"
+      if int(root.get('errors')) != 0 or int(root.get('failures')) != 0:
+        # only upload to s3 if test output contains errors
+        args['key'] = uuid.uuid1()
+        LOG.info('uploading %s to s3 with key %s ' % (test_report, args['key']))
+        archive = self.compress_file(test_report, args['job_id'] + args['result_id'])
+        self._upload_string_to_s3(args['key'], archive.getvalue())
+      else:
+        LOG.info('all tests passed in %s, skip uploading' % test_report)
+        args['key'] = "success"
+    else:
+      # We're given an archive that's already uploaded to s3
+      root = self.get_root_from_s3key(args['key'])
+
+    return self.populate_database(args['job_id'], args['result_id'], args['revision'], args['hostname'], root, args['key'])
+
+  @cherrypy.expose
+  def download_log(self, key):
+    expiry = 60 * 60 * 24 # link should last 1 day
+    k = boto.s3.key.Key(self.s3_bucket)
+    k.key = key
+    raise cherrypy.HTTPRedirect(k.generate_url(expiry))
+
+  @cherrypy.expose
+  def diagnose(self, key, name):
+    log_text = self._download_string_from_s3(key)
+
+    (msg, st, stdout, stderr) = parse_test_failure.extract_failure_summary(log_text, name)
+    template = Template("""
+      <h1>Error Message</h1>
+      <code><pre>{{ msg|e }}</pre></code>
+      <h1>Stack Trace</h1>
+      <code><pre>{{ st|e }}</pre></code>
+      <h1>Standard Output</h1>
+      <code><pre>{{ stdout|e }}</pre></code>
+      <h1>Standard Error</h1>
+      <code><pre>{{ stderr|e }}</pre></code>
+    """)
+    return self.render_container(template.render(msg=msg, st=st, stdout=stdout, stderr=stderr))
+
+  def recently_failed_html(self):
+    """ Return an HTML report of recently failed tests """
+    c = self._execute_query(
+      "SELECT * from dist_test_results WHERE status != 0 "
+      "AND timestamp > NOW() - INTERVAL 1 WEEK "
+      "ORDER BY timestamp DESC LIMIT 50")
+    failed_tests = c.fetchall()
+
+    prev_date = None
+    for t in failed_tests:
+      t['is_new_date'] = t['timestamp'].date() != prev_date
+      prev_date = t['timestamp'].date()
+
+    template = Template("""
+    <h1>50 most recent failures</h1>
+    <table class="table">
+      <tr>
+        <th>test</th>
+        <th>exit code</th>
+        <th>rev</th>
+        <th>machine</th>
+        <th>time</th>
+      </tr>
+      {% for run in failed_tests %}
+        {% if run.is_new_date %}
+          <tr class="new-date">
+            <th colspan="7">{{ run.timestamp.date()|e }}</th>
+          </tr>
+        {% endif %}
+        <tr>
+          <td><a href="/test_drilldown?test_name={{ run.test_name |urlencode }}">
+              {{ run.test_name |e }}
+              </a></td>
+          <td>{{ run.status |e }}
+            {% if run.log_key %}
+              <a href="/download_log?key={{ run.log_key |urlencode }}">download log</a> |
+              <a href="/diagnose?key={{ run.log_key |urlencode }}&name={{ run.test_name |urlencode }}">diagnose</a>
+            {% endif %}
+          </td>
+          <td>{{ run.revision |e }}</td>
+          <td>{{ run.hostname |e }}</td>
+          <td>{{ run.timestamp |e }}</td>
+        </tr>
+      {% endfor %}
+    </table>
+    """)
+    return template.render(failed_tests=failed_tests)
+
+  def flaky_report_html(self):
+    """ Return an HTML report of recently flaky tests """
+    c = self._execute_query(
+                  """SELECT DISTINCT test_name
+                    FROM dist_test_results
+                    WHERE timestamp > NOW() - INTERVAL 1 WEEK AND status != 0""")
+    names = c.fetchall()
+
+    query_string = """SELECT test_name,
+                   DATEDIFF(NOW(), timestamp) AS days_ago,
+                   SUM(IF(status != 0, 1, 0)) AS num_failures,
+                   COUNT(*) AS num_runs
+                 FROM dist_test_results
+                 WHERE timestamp > NOW() - INTERVAL 1 WEEK AND test_name in"""\
+                   + "('" + "','".join(str(n['test_name']) for n in names) + "')"\
+                   + """GROUP BY test_name, days_ago
+                   ORDER BY test_name"""
+    c = self._execute_query(query_string)
+    rows = c.fetchall()
+
+    results = []
+    for test_name, test_rows in itertools.groupby(rows, lambda r: r['test_name']):
+      # Convert to list so we can consume it multiple times
+      test_rows = list(test_rows)
+
+      # Compute summary for last 7 days and last 2 days
+      runs_7day = sum(r['num_runs'] for r in test_rows)
+      failures_7day = sum(r['num_failures'] for r in test_rows)
+      runs_2day = sum(r['num_runs'] for r in test_rows if r['days_ago'] < 2)
+      failures_2day = sum(r['num_failures'] for r in test_rows if r['days_ago'] < 2)
+
+      # Compute a sparkline (percentage failure for each day)
+      sparkline = [0 for x in xrange(8)]
+      for r in test_rows:
+        if r['num_runs'] > 0:
+          percent = float(r['num_failures']) / r['num_runs'] * 100
+        else:
+          percent = 0
+        sparkline[7 - r['days_ago']] = percent
+
+      # Add to results list for tablet.
+      results.append(dict(test_name=test_name,
+                          runs_7day=runs_7day,
+                          failures_7day=failures_7day,
+                          runs_2day=runs_2day,
+                          failures_2day=failures_2day,
+                          sparkline=",".join("%.2f" % p for p in sparkline)))
+
+      results = sorted(results, key=itemgetter('failures_7day'), reverse=True)
+    return Template("""
+    <h1>Flaky rate over last week</h1>
+    <table class="table" id="flaky-rate">
+      <tr>
+       <th>test</th>
+       <th>failure rate (7-day)</th>
+       <th>failure rate (2-day)</th>
+       <th>trend</th>
+      </tr>
+      {% for r in results %}
+      <tr>
+        <td><a href="/test_drilldown?test_name={{ r.test_name |urlencode }}">
+              {{ r.test_name |e }}
+            </a></td>
+        <td>{{ r.failures_7day |e }} / {{ r.runs_7day }}
+            ({{ "%.2f"|format(r.failures_7day / r.runs_7day * 100) }}%)
+        </td>
+        <td>{{ r.failures_2day |e }} / {{ r.runs_2day }}
+            {% if r.runs_2day > 0 %}
+            ({{ "%.2f"|format(r.failures_2day / r.runs_2day * 100) }}%)
+            {% endif %}
+        </td>
+        <td><span class="inlinesparkline">{{ r.sparkline |e }}</span></td>
+      </tr>
+      {% endfor %}
+    </table>
+    <script type="text/javascript">
+      $(function() {
+        $('.inlinesparkline').sparkline('html', {
+           'height': 25,
+            'width': '40px',
+            'chartRangeMin': 0,
+            'tooltipFormatter': function(sparkline, options, fields) {
+              return String(7 - fields.x) + "d ago: " + fields.y + "%"; }
+        });
+      });
+    </script>
+    """).render(results=results)
+
+  @cherrypy.expose
+  def list_failed_tests(self, build_pattern, num_days):
+    num_days = int(num_days)
+    c = self._execute_query(
+              """SELECT DISTINCT
+                   test_name
+                 FROM dist_test_results
+                 WHERE timestamp > NOW() - INTERVAL %(num_days)s DAY
+                   AND status != 0
+                   AND build_id LIKE %(build_pattern)s""",
+              dict(build_pattern=build_pattern,
+                   num_days=num_days))
+    cherrypy.response.headers['Content-Type'] = 'text/plain'
+    return "\n".join(row['test_name'] for row in c.fetchall())
+
+  @cherrypy.expose
+  def test_drilldown(self, test_name):
+    # Get summary statistics for the test, grouped by revision
+    c = self._execute_query(
+              """SELECT
+                   revision,
+                   MIN(timestamp) AS first_run,
+                   SUM(IF(status != 0, 1, 0)) AS num_failures,
+                   COUNT(*) AS num_runs
+                 FROM dist_test_results
+                 WHERE timestamp > NOW() - INTERVAL 1 WEEK
+                   AND test_name = %(test_name)s
+                 GROUP BY revision
+                 ORDER BY first_run DESC""",
+              dict(test_name=test_name))
+    revision_rows = c.fetchall()
+
+    # Convert to a dictionary, by revision
+    rev_dict = dict( [(r['revision'], r) for r in revision_rows] )
+
+    # Add an empty 'runs' array to each revision to be filled in below
+    for r in revision_rows:
+      r['runs'] = []
+
+    # Append the specific info on failures
+    c.execute("SELECT * from dist_test_results "
+              "WHERE timestamp > NOW() - INTERVAL 1 WEEK "
+              "AND test_name = %(test_name)s "
+              "AND status != 0",
+              dict(test_name=test_name))
+    for failure in c.fetchall():
+      rev_dict[failure['revision']]['runs'].append(failure)
+
+    return self.render_container(Template("""
+    <h1>{{ test_name |e }} flakiness over recent revisions</h1>
+    <a href="/">Back to home</a>
+    {% for r in revision_rows %}
+      <h4>{{ r.revision }} (Failed {{ r.num_failures }} / {{ r.num_runs }})</h4>
+      {% if r.num_failures > 0 %}
+        <table class="table">
+          <tr>
+            <th>time</th>
+            <th>failed test</th>
+            <th>exit code</th>
+            <th>machine</th>
+            <th>build</th>
+          </tr>
+          {% for run in r.runs %}
+            <tr {% if run.status != 0 %}
+                  style="background-color: #faa;"
+                {% else %}
+                  style="background-color: #afa;"
+                {% endif %}>
+              <td>{{ run.timestamp |e }}</td>
+              <td>{{ run.test_name |e }}
+              </td>
+              <td>{{ run.status |e }}
+                {% if run.log_key %}
+                  <a href="/download_log?key={{ run.log_key |urlencode }}">download log</a> |
+                  <a href="/diagnose?key={{ run.log_key |urlencode }}&name={{ run.test_name |urlencode }}">diagnose</a>
+                {% endif %}
+              </td>
+              <td>{{ run.hostname |e }}</td>
+              <td>{{ run.build_id |e }}</td>
+            </tr>
+          {% endfor %}
+        </table>
+      {% endif %}
+    {% endfor %}
+    """).render(revision_rows=revision_rows, test_name=test_name))
+
+  @cherrypy.expose
+  def index(self):
+    body = self.flaky_report_html()
+    body += "<hr/>"
+    body += self.recently_failed_html()
+    return self.render_container(body)
+
+  def render_container(self, body):
+    """ Render the "body" HTML inside of a bootstrap container page. """
+    template = Template("""
+    <!DOCTYPE html>
+    <html>
+      <head><title>Test results dashboard</title>
+      <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" />
+      <style>
+        .new-date { border-bottom: 2px solid #666; }
+        #flaky-rate tr :nth-child(1) { width: 70%; }
+
+        /* make sparkline data not show up before loading */
+        .inlinesparkline { color: #fff; }
+        /* fix sparkline tooltips */
+        .jqstooltip {
+          -webkit-box-sizing: content-box;
+          -moz-box-sizing: content-box;
+          box-sizing: content-box;
+        }
+      </style>
+    </head>
+    <body>
+      <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+      <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-sparklines/2.1.2/jquery.sparkline.min.js"></script>
+      <div class="container-fluid">
+      {{ body }}
+      </div>
+    </body>
+    </html>
+    """)
+    return template.render(body=body)
+
+if __name__ == "__main__":
+  config = Config()
+  logging.basicConfig(level=logging.INFO)
+  LOG = logging.getLogger('dist_test.test_result_server')
+  cherrypy.config.update(
+    {'server.socket_host': '0.0.0.0',
+     'response.timeout': 1800} )
+  LOG.info("Starting test result server")
+  cherrypy.quickstart(ResultServer(config))

--- a/infra/server.py
+++ b/infra/server.py
@@ -316,7 +316,8 @@ class DistTestServer(object):
     if result['total_groups'] == result['finished_groups']:
       result['status'] = "finished"
       finish_time = max([t["complete_timestamp"] for t in tasks])
-      stop = finish_time
+      if finish_time is not None:
+        stop = finish_time
     runtime = stop - submit_time
 
     # Compute sum of failed tasks in each flaky group

--- a/infra/slave.py
+++ b/infra/slave.py
@@ -142,9 +142,11 @@ class Slave(object):
   def make_archive(self, task, test_dir):
     # Return early if no test_dir is specified
     if test_dir is None:
+      LOG.warn("test_dir not given, skipping archive")
       return None
     # Return early if there are no globs specified
     if task.task.artifact_archive_globs is None or len(task.task.artifact_archive_globs) == 0:
+      LOG.warn("archive glob not given, skipping archive")
       return None
     all_matched = set()
     total_size = 0
@@ -153,8 +155,8 @@ class Slave(object):
           matched = glob2.iglob(test_dir + "/" + g)
           for m in matched:
             canonical = os.path.realpath(m)
-            if not canonical.startswith(test_dir):
-              LOG.warn("Glob %s matched file outside of test_dir, skipping: %s" % (g, canonical))
+            if sys.platform != "darwin" and (not canonical.startswith(test_dir)): # work around on mac os
+              LOG.warn("Glob %s matched file outside of test_dir %s, skipping: %s (sys=%s)" % (g, test_dir, canonical, sys.platform))
               continue
             total_size += os.stat(canonical).st_size
             all_matched.add(canonical)

--- a/infra/slave.py
+++ b/infra/slave.py
@@ -25,6 +25,7 @@ import subprocess
 import sys
 import threading
 import time
+import contextlib
 import zipfile
 
 from config import Config
@@ -169,7 +170,7 @@ class Slave(object):
                + "uploading archive with error message instead.",
               task.task.get_id(), total_size, max_size)
       archive_buffer = cStringIO.StringIO()
-      with zipfile.ZipFile(archive_buffer, "w") as myzip:
+      with contextlib.closing(zipfile.ZipFile(archive_buffer , "w")) as myzip:
         myzip.writestr("_ARCHIVE_TOO_BIG_",
                        "Size of matched uncompressed test artifacts exceeded maximum size" \
                        + "(%d bytes > %d bytes)!" % (total_size, max_size))
@@ -177,7 +178,7 @@ class Slave(object):
 
     # Write out the archive
     archive_buffer = cStringIO.StringIO()
-    with zipfile.ZipFile(archive_buffer, "w", zipfile.ZIP_DEFLATED) as myzip:
+    with contextlib.closing(zipfile.ZipFile(archive_buffer , "w", zipfile.ZIP_DEFLATED)) as myzip:
       for m in all_matched:
         arcname = os.path.relpath(m, test_dir)
         while arcname.startswith("/"):

--- a/infra/submit_results.py
+++ b/infra/submit_results.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+
+import argparse
+import config
+import fnmatch
+import os
+import socket
+import subprocess
+from subprocess import PIPE
+import urllib
+import urllib2
+try:
+  import simplejson as json
+except:
+  import json
+
+config = config.Config()
+config.ensure_result_server_configured()
+
+def submit_result(params):
+  print "submitting result to server:", params
+  url = config.DIST_TEST_RESULT_SERVER + "/add_result?" + urllib.urlencode(params)
+  results_str = urllib2.urlopen(url).read()
+  print results_str
+
+# TODO support submitting a test result file.
+# def add_one_result(path):
+#   if os.path.isfile(path):
+#     args = get_parser().parse_args(['-f', path])
+#   elif os.path.isdir(path):
+#     args = get_parser().parse_args(['-p', path])
+#   else:
+#       print "unknown path type", path
+#       return
+#   add_results(args)
+
+def crawl_job(params):
+  print "crawling job(%s) from server." % params['job_id']
+  url = config.DIST_TEST_RESULT_SERVER + "/crawl_from_jobid?" + urllib.urlencode(params)
+  results_str = urllib2.urlopen(url).read()
+  print results_str
+
+def add_results(args):
+  params = {}
+  if args.jobid:
+      params["job_id"] = args.jobid
+  else:
+      print "Error: no job id given. jobid is required."
+      return False
+
+  if args.file is None and args.path is None and args.key is None:
+      print "Info: No file / path / key given. Will crawl the job directly from database."
+      crawl_job(params)
+
+  if args.taskid:
+      params['task_id'] = args.taskid
+
+  if args.hostname:
+    params["hostname"] = args.hostname
+  else:
+    params["hostname"] = socket.gethostname()
+
+  #TODO: cd project root and get git hash
+  p = subprocess.Popen(["git", "rev-parse", "HEAD"], stdout=PIPE)
+  params['revision'] = p.communicate()[0]
+  d1 = subprocess.Popen(["git", "diff", "--quiet"])
+  d1.communicate()
+  d2 = subprocess.Popen(["git", "diff", "--quiet", "--cached"])
+  d2.communicate()
+  if d1.returncode != 0 or d2.returncode != 0:
+    params['revision'] += "-dirty"
+
+  # TODO: below are all untested and used for now...
+  # add all files to result
+  if args.file:
+    for f in args.file:
+        params['test_report'] = os.path.abspath(f)
+        submit_result(params)
+
+  # recursively add all TEST-*.xml under path to result
+  if args.path:
+    for root, dirs, files in os.walk(args.path):
+        for f in fnmatch.filter(files, 'TEST-*.xml'):
+            params['test_report'] = os.path.abspath(os.path.join(root, f))
+            submit_result(params)
+
+  if args.key:
+    params["key"] = args.key
+    submit_result(params)
+
+  return True
+
+def get_parser():
+  parser = argparse.ArgumentParser(description='Submit a test result to the result server.',
+                                   epilog="Example: " \
+                                   "submit_results.py -k 'key_on_s3' -t 'task_id'")
+  parser.add_argument("-i", "--hostname", help='Specifies the hostname that the test was run')
+  parser.add_argument("-f", "--file", action="append", help='The test result file(s)')
+  parser.add_argument("-t", "--taskid", help='The task id')
+  parser.add_argument("-j", "--jobid", help='The job id')
+  parser.add_argument("-p", "--path", help='The path under which the test was run')
+  parser.add_argument("-k", "--key", help='The key of the file stored in s3')
+  return parser
+
+if __name__ == "__main__":
+  args = get_parser().parse_args()
+  if add_results(args) != True:
+    get_parser().print_help()


### PR DESCRIPTION
Added a test result server similar to kudu's result server., as the temporary work from hdfs fix-it day. @umbrant could you please review?

High level, grind user can specify `--submit-result` when running `grind test`, to submit the result to the result server after the test is done. Submission is based on jobid. Result server connects to the same db as the test server, and will search for all entries with that job id, and populate its own test_result table. This way all the s3 objects are reused directly (without any download/upload), and theoretically works with any tests that can run with grind.

Most notable TODO is allowing submitting local result (a mvn test output xml, or a directory of surefire tests), others commented as TODO in code.