### PR TITLE
Update packager to respect maven_flags

### DIFF
--- a/grind/bin/grind
+++ b/grind/bin/grind
@@ -384,7 +384,8 @@ class TestRunner:
     def run(self):
         if self.args.list_modules:
             # Do not include any modules, this way we skip looking for tests
-            i = isolate.Isolate(self.project_dir, self.output_dir, include_modules=[])
+            maven_flags = os.environ.get('GRIND_MAVEN_FLAGS')
+            i = isolate.Isolate(self.project_dir, self.output_dir, include_modules=[], maven_flags=maven_flags)
             print "Found %s modules in directory %s" \
                     % (len(i.maven_project.modules), i.maven_project.project_root)
             TestRunner.print_module_tree(i.maven_project.root_module)

--- a/grind/python/disttest/packager.py
+++ b/grind/python/disttest/packager.py
@@ -364,6 +364,7 @@ class Packager:
 
         # TODO: add support for specifying additional dependencies not caught by above
         # This is required if we ever want to be able to invoke tests in offline mode.
+        # https://maven.apache.org/plugins/maven-dependency-plugin/go-offline-mojo.html may be helpful.
         # Need to make this generalized, per-project config file?
 
     @staticmethod


### PR DESCRIPTION
Pin mvn dependency plugin to a 2.x version since 3.0.2 has incompatible behaviors that broke grind with Hadoop 3