### PR TITLE
#56 - test artifact check removed from isolate.py

### DIFF
--- a/grind/python/disttest/isolate.py
+++ b/grind/python/disttest/isolate.py
@@ -152,9 +152,6 @@ run mvn -version
         num_written = 0
         for module in self.maven_project.modules:
             rel_pom = os.path.relpath(module.pom, self.maven_project.project_root)
-            if len(module.test_artifacts) == 0:
-                logger.debug("Skipping module with no compiled test-sources jar: %s", module.root)
-                continue
             for test in module.test_classes:
                 filename = os.path.join(self.output_dir, "%s.isolated.gen.json" % test.name)
                 args = ["-i", self.__ISOLATE_NAME, "-s", test.name + ".isolated"]


### PR DESCRIPTION
There is a check related the existance of the test artifacts the isolate.py file. If there is no such artifact, no isolate files are generated: https://github.com/cloudera/dist_test/blob/master/grind/python/disttest/isolate.py#L155

By default no test artifacts are generated, this *test.jar files are generated by using the maven-jar-plugin. This plugin is missing from a couple of places. I think we should remove this check.