### PR TITLE
Fix handling of commands with relative path

### DIFF
--- a/infra/file_path.py
+++ b/infra/file_path.py
@@ -51,6 +51,15 @@ def make_tree_writeable(root):
       for dirname in dirnames:
         set_read_only(os.path.join(dirpath, dirname), False)
 
+def ensure_command_has_abs_path(command, cwd):
+  """Ensures that an isolate command uses absolute path.
+
+  This is needed since isolate can specify a command relative to 'cwd' and
+  subprocess.call doesn't consider 'cwd' when searching for executable.
+  """
+  if not os.path.isabs(command[0]):
+    command[0] = os.path.abspath(os.path.join(cwd, command[0]))
+
 def is_same_filesystem(path1, path2):
   """Returns True if both paths are on the same filesystem.
 


### PR DESCRIPTION
After the recent change to manually run the command instead of using
run_isolated.py we lost some functionality pertaining to paths.

Apparently grind submits jobs with no 'relative_cwd' and with the command set
to 'run_test.sh'. This caused two problems in our code:

- we were always assuming 'relative_cwd' was set. If it's not set it should
  default to the root of the test bundle.
- we were not handling the case that 'command' was a script in the same working
  directory (eg 'run_test.sh'). We assumed it would always be a longer path
  like 'foo/bar/run_test.sh'.

When I tested the prior change I had used Kudu's dist_test integration which
always sets a relative_cwd and runs a script in a subdirectory, so hadn't
noticed the problems.

This change is already running on the deployed infrastructure and appears to be
processing the job queue effectively.