### PR TITLE
[infra] increased client wait poll interval 10x

### DIFF
--- a/infra/client.py
+++ b/infra/client.py
@@ -149,7 +149,7 @@ def do_watch_results(job_id):
       return retcode
 
     # Sleep until next interval
-    time.sleep(0.5)
+    time.sleep(5)
 
 def save_last_job_id(job_id):
   with file(LAST_JOB_PATH, "w") as f:


### PR DESCRIPTION
This patch increases the poll interval for to fetch updates on the task status from 0.5 to 5 seconds.  That's to put less stress on the dist-test infrastracture servers.